### PR TITLE
chore(docs): simplify Go installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,7 @@ See the [install instructions](https://golang.org/doc/install.html).
 
 Compiling mastotool is easy, simply run:
 
-    git clone https://github.com/muesli/mastotool.git
-    cd mastotool
-    go build
+    go install github.com/muesli/mastotool@latest
 
 ## Usage
 


### PR DESCRIPTION
When reading the README, it came to my attention that the Go installation instructions could be written much shorter, as exemplified in the attached commit and tested locally.